### PR TITLE
Check for updated translate key on every render call

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,17 +51,13 @@ var Translate = React.createClass({
     this.setState({ locale: newLocale });
   },
 
-  key: null,
-
   render: function() {
     var container   = this.props.component || React.DOM.span;
     var textContent = Translate.textContentComponents.indexOf(container) > -1;
     var interpolate = textContent || this.props.unsafe === true;
     var options     = extend({ locale: this.state.locale }, this.props, { interpolate: interpolate });
 
-    this.key = this.key || this.props.children;
-
-    var translation = translate(this.key, options);
+    var translation = translate(this.props.children, options);
 
     delete options.locale;
     delete options.scope;


### PR DESCRIPTION
Currently, if the key of an already mounted translate-component gets changed in-between render calls, the translate component sticks to the old translation key, because "this.key" has already been set. This change allows for updating translation keys of already mounted translate components.

(This change is passing all the tests. Please tell me if you want me to write a new test for this.)
