### PR TITLE
Bumped peer dependency of counterpart

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "react": "^15.5.4",
-    "counterpart": "^0.17.0",
+    "counterpart": "^0.18.0",
     "react-interpolate-component": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When using counterpart 0.18.x and react-translate-component you will run into problems because both counterpart 0.18.x and 0.17.x will be downloaded when installing npm packages. 

react-translate-component will then use version 0.17.x internally (in its own node_modules) and all resources are registered through version 0.18.x, which will result in "missing translation" errors

this bump for counterpart should fix the problem